### PR TITLE
Fix macos m1

### DIFF
--- a/examples/bevy/README.md
+++ b/examples/bevy/README.md
@@ -34,7 +34,7 @@ pub fn player_movement_system(
     keyboard_input: Res<Input<KeyCode>>,
     mut query: Query<&mut Transform, With<Player>>,
 ) { /*...*/ }
-``
+```
 
 `generate_bevy_systems` will 
 

--- a/examples/reload-feature/Cargo.toml
+++ b/examples/reload-feature/Cargo.toml
@@ -14,5 +14,5 @@ lib = { path = "lib" }
 log = "^0.4"
 
 [features]
-default = ["reload"]
+default = []
 reload = ["dep:hot-lib-reloader"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This reverts back to the strategy of copying the actually loaded lib file to a filename unknown to the runtime.

So if the original lib is `target/debug/liblib.dylib`, the (re-)loaded lib files are `target/debug/liblib-hot.0.dylib`, `target/debug/liblib-hot.1.dylib`, ...

This fixes reloads on macOS arm64 / M1