### PR TITLE
fix how we lock the lib loader

### DIFF
--- a/macro/src/hot_module/code_gen.rs
+++ b/macro/src/hot_module/code_gen.rs
@@ -10,28 +10,12 @@ pub(crate) fn generate_lib_loader_items(
     span: Span,
 ) -> Result<proc_macro2::TokenStream> {
     let result = quote::quote_spanned! {span=>
-        static mut SYMBOLS_IN_USE: Option<::std::sync::Arc<::std::sync::atomic::AtomicUsize>> = None;
-        static SYMBOLS_IN_USE_INIT: ::std::sync::Once = ::std::sync::Once::new();
-
-        fn symbols_in_use() -> ::std::sync::Arc<::std::sync::atomic::AtomicUsize> {
-            SYMBOLS_IN_USE_INIT.call_once(|| {
-                // Safety: guarded by Once, will only be called one time.
-                unsafe {
-                    use ::std::borrow::BorrowMut;
-                    *SYMBOLS_IN_USE.borrow_mut() = Some(::std::sync::Arc::new(::std::sync::atomic::AtomicUsize::new(0)));
-                }
-            });
-
-            // Safety: Once runs before and initializes the global
-            unsafe { SYMBOLS_IN_USE.as_ref().cloned().unwrap() }
-        }
-
-        static mut LIB_CHANGE_NOTIFIER: Option<::std::sync::Arc<::std::sync::Mutex<::hot_lib_reloader::LibReloadNotifier>>> = None;
+        static mut LIB_CHANGE_NOTIFIER: Option<::std::sync::Arc<::std::sync::RwLock<::hot_lib_reloader::LibReloadNotifier>>> = None;
         static LIB_CHANGE_NOTIFIER_INIT: ::std::sync::Once = ::std::sync::Once::new();
 
-        fn __lib_notifier() -> ::std::sync::Arc<::std::sync::Mutex<::hot_lib_reloader::LibReloadNotifier>> {
+        fn __lib_notifier() -> ::std::sync::Arc<::std::sync::RwLock<::hot_lib_reloader::LibReloadNotifier>> {
             LIB_CHANGE_NOTIFIER_INIT.call_once(|| {
-                let notifier = ::std::sync::Arc::new(::std::sync::Mutex::new(Default::default()));
+                let notifier = ::std::sync::Arc::new(::std::sync::RwLock::new(Default::default()));
                 // Safety: guarded by Once, will only be called one time.
                 unsafe {
                     use ::std::borrow::BorrowMut;
@@ -43,48 +27,50 @@ pub(crate) fn generate_lib_loader_items(
             unsafe { LIB_CHANGE_NOTIFIER.as_ref().cloned().unwrap() }
         }
 
-        static mut LIB_LOADER: Option<::std::sync::Arc<::std::sync::Mutex<::hot_lib_reloader::LibReloader>>> = None;
+        fn __lib_loader_subscription() -> ::hot_lib_reloader::LibReloadObserver {
+            __lib_notifier()
+                .write()
+                .expect("write lock notifier")
+                .subscribe()
+        }
+
+        static mut LIB_LOADER: Option<::std::sync::Arc<::std::sync::RwLock<::hot_lib_reloader::LibReloader>>> = None;
         static LIB_LOADER_INIT: ::std::sync::Once = ::std::sync::Once::new();
 
-        fn __lib_loader() -> ::std::sync::Arc<::std::sync::Mutex<::hot_lib_reloader::LibReloader>> {
+        fn __lib_loader() -> ::std::sync::Arc<::std::sync::RwLock<::hot_lib_reloader::LibReloader>> {
             LIB_LOADER_INIT.call_once(|| {
                 let mut lib_loader = ::hot_lib_reloader::LibReloader::new(#lib_dir, #lib_name)
                     .expect("failed to create hot reload loader");
 
                 let change_rx = lib_loader.subscribe_to_file_changes();
-                let lib_loader = ::std::sync::Arc::new(::std::sync::Mutex::new(lib_loader));
+                let lib_loader = ::std::sync::Arc::new(::std::sync::RwLock::new(lib_loader));
                 let lib_loader_for_update = lib_loader.clone();
-                let symbols_in_use = symbols_in_use();
 
                 // update thread that triggers the dylib to be actually updated
                 let _thread = ::std::thread::spawn(move || {
                     loop {
                         if let Ok(()) = change_rx.recv() {
-                            // if there are pending function calls we have lended out symbols and can't
-                            // reload the lib, otherwise those symbols would be dangling.
-                            while symbols_in_use.load(::std::sync::atomic::Ordering::SeqCst) > 0 {
-                                println!("[hot-lib-loader] delaying update as symbols are currently in use");
-                                ::std::thread::sleep(::std::time::Duration::from_millis(500));
-                            }
-
                             // inform subscribers about about-to-reload
-                            if let Ok(notifier) = __lib_notifier().lock() {
-                                notifier.send_about_to_reload_event_and_wait_for_blocks();
-                            }
+                            __lib_notifier()
+                                .read()
+                                .expect("read lock notifier")
+                                .send_about_to_reload_event_and_wait_for_blocks();
 
                             // get lock to lib_loader, make sure to not deadlock on it here
                             loop {
-                                if let Ok(mut lib_loader) = lib_loader_for_update.try_lock() {
+                                if let Ok(mut lib_loader) = lib_loader_for_update.try_write() {
                                     let _ = !lib_loader.update().expect("hot lib update()");
                                     break;
                                 }
-                                ::std::thread::sleep(::std::time::Duration::from_millis(20));
+                                println!("[hot-lib-reloader] trying to get a write lock");
+                                ::std::thread::sleep(::std::time::Duration::from_millis(1));
                             }
 
                             // inform subscribers about lib reloaded
-                            if let Ok(notifier) = __lib_notifier().lock() {
-                                notifier.send_reloaded_event();
-                            }
+                            __lib_notifier()
+                                .read()
+                                .expect("read lock notifier")
+                                .send_reloaded_event();
                         }
                     }
                 });
@@ -100,11 +86,6 @@ pub(crate) fn generate_lib_loader_items(
             unsafe { LIB_LOADER.as_ref().cloned().unwrap() }
         }
 
-        fn __lib_loader_subscription() -> ::hot_lib_reloader::LibReloadObserver {
-            let notifier = __lib_notifier();
-            let mut notifier = notifier.lock().expect("lib loader mutex unlock failed");
-            notifier.subscribe()
-        }
     };
 
     Ok(result)
@@ -153,24 +134,14 @@ pub(crate) fn gen_hot_module_function_for(
 
     let block = syn::parse_quote! {
         {
-            let sym = {
-                let lib_loader = __lib_loader();
-                let lib_loader = lib_loader.lock().expect("lib loader mutex unlock failed");
-                let sym = unsafe {
-                    lib_loader
-                        .get_symbol::<fn( #( #input_types ),* ) #ret_type >(#symbol_name)
-                        .expect(#err_msg_load_symbol)
-                };
-                symbols_in_use().fetch_add(1, ::std::sync::atomic::Ordering::SeqCst);
-                unsafe { sym.into_raw() }
+            let lib_loader = __lib_loader();
+            let lib_loader = lib_loader.read().expect("lib loader RwLock read failed");
+            let sym = unsafe {
+                lib_loader
+                    .get_symbol::<fn( #( #input_types ),* ) #ret_type >(#symbol_name)
+                    .expect(#err_msg_load_symbol)
             };
-
-            // TODO catch unwind? Types need to be compatible...
-            let result = sym( #( #input_names ),* );
-
-            symbols_in_use().fetch_sub(1, ::std::sync::atomic::Ordering::SeqCst);
-
-            result
+            sym( #( #input_names ),* )
         }
     };
 


### PR DESCRIPTION
I used a convoluted half-baked incorrect ref counting scheme for access to
symbols while not needing to mutex lock the lib loader during a call (so that
recursive calls work)

This is much better addressed with a RwLock that.

This cleans up both the `__lib_loader()` and `__lib_notifier()` accessors. It
should also fix spurious crashes during hot updates that were likely caused by
symbols actually being used (b/c the prev solution wasn't really thread safe).