### PR TITLE
Add `crate` attribute to `hot_module` proc-macro

### DIFF
--- a/macro/src/hot_module/module_body.rs
+++ b/macro/src/hot_module/module_body.rs
@@ -234,13 +234,14 @@ impl quote::ToTokens for HotModule {
             lib_name,
             lib_dir,
             file_watch_debounce_ms,
+            crate_name,
         } = match hot_module_args {
             None => panic!("Expected to have macro attributes"),
             Some(attributes) => attributes,
         };
 
         let lib_loader =
-            generate_lib_loader_items(lib_dir, lib_name, file_watch_debounce_ms, tokens.span())
+            generate_lib_loader_items(lib_dir, lib_name, file_watch_debounce_ms, crate_name, tokens.span())
                 .expect("error generating hot lib loader helpers");
 
         let module_def = quote::quote! {

--- a/tests/lib-loader-test.rs
+++ b/tests/lib-loader-test.rs
@@ -1,11 +1,13 @@
 mod common;
 
-#[hot_lib_reloader::hot_module(dylib = "lib_for_testing", file_watch_debounce = 50)]
+use hot_lib_reloader as hlibr_crate_alias;
+
+#[hlibr_crate_alias::hot_module(dylib = "lib_for_testing", file_watch_debounce = 50, crate = "super::hlibr_crate_alias")]
 mod hot_lib {
     hot_functions_from_file!("tests/lib_for_testing/src/lib.rs");
 
     #[lib_change_subscription]
-    pub fn subscribe() -> hot_lib_reloader::LibReloadObserver {}
+    pub fn subscribe() -> super::hlibr_crate_alias::LibReloadObserver {}
 
     #[lib_version]
     pub fn version() -> usize {}
@@ -57,7 +59,7 @@ fn test() {
             // wait for reload to be completed
             lib_observer.wait_for_reload();
 
-            // make rue lib is new
+            // make sure lib is new
             let n = hot_lib::do_more_stuff(Box::new(hot_lib::do_stuff));
             assert_eq!(n, 7);
             assert_eq!(hot_lib::version(), 1);


### PR DESCRIPTION
Make it possible for users to specify what crate name is inside the generated module code.

This allow usage with aliases crate name
and re-export hot-lib-reloader-rs from another crate

Fix #27 