### PR TITLE
Added loaded library name templating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ libloading = "^0.7"
 log = "0.4.17"
 notify = "^4"
 thiserror = "1.0.32"
-rand = "0.8.5"
-uuid = {  version = "1.4.1", features = ["v4"] }
+rand = { version = "0.8.5", optional = true }
+uuid = {  version = "1.4.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
 env_logger = "^0.9"
@@ -33,3 +33,5 @@ exclude = ["examples"]
 [features]
 default = []
 verbose = []
+rand = [ "dep:rand" ]
+uuid = [ "dep:uuid" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ libloading = "^0.7"
 log = "0.4.17"
 notify = "^4"
 thiserror = "1.0.32"
+rand = "0.8.5"
+uuid = {  version = "1.4.1", features = ["v4"] }
 
 [dev-dependencies]
 env_logger = "^0.9"

--- a/README.md
+++ b/README.md
@@ -383,6 +383,34 @@ mod hot_lib {
 }
 ```
 
+### Adjust the shadow filename
+
+The `hot_module` macro allows setting the shadow file name using the `loaded_lib_name_template` parameter. 
+This is useful when multiple processes are trying to hot reload the same library and can be used to prevent conflicts.
+This attribute allows for placeholders that can be dynamically replaced:
+
+| Placeholder       | Description                                        | Feature Flag  |
+|-------------------|----------------------------------------------------|---------------|
+| `{lib_name}`      | Name of the library as defined in your code        | None          |
+| `{load_counter}`  | Incremental counter for each hot reload            | None          |
+| `{pid}`           | Process ID of the running application              | None          |
+| `{rand}`          | A random `u32` value                               | `rand`        |
+| `{uuid}`          | A UUID v4 string                                   | `uuid`        |
+
+If you don't specify the `loaded_lib_name_template` parameter, a default naming convention is used for the shadow filename. 
+This default pattern is: `{lib_name}-hot-{load_counter}`.
+
+```rust
+#[hot_lib_reloader::hot_module(
+    dylib = "lib",
+    // Might result in the following shadow file lib_hot_2644_0_3945339610_5e659d6e-b78c-4682-9cdd-b8a0cd3e8fc6.dll
+    // Requires the 'rand' and 'uuid' feature flags for the {rand} and {uuid} placeholders
+    loaded_lib_name_template = "{lib_name}_hot_{pid}_{load_counter}_{rand}_{uuid}"
+)]
+mod hot_lib {
+    /* ... */
+}
+```
 
 ### Debugging
 

--- a/macro/src/hot_module/code_gen.rs
+++ b/macro/src/hot_module/code_gen.rs
@@ -9,6 +9,7 @@ pub(crate) fn generate_lib_loader_items(
     lib_name: &Expr,
     file_watch_debounce_ms: &LitInt,
     crate_name: &Path,
+    loaded_lib_name_template: &Expr,
     span: Span,
 ) -> Result<proc_macro2::TokenStream> {
     let result = quote::quote_spanned! {span=>
@@ -50,7 +51,7 @@ pub(crate) fn generate_lib_loader_items(
 
         fn __lib_loader() -> ::std::sync::Arc<::std::sync::RwLock<#crate_name::LibReloader>> {
             LIB_LOADER_INIT.call_once(|| {
-                let mut lib_loader = #crate_name::LibReloader::new(#lib_dir, #lib_name, Some(::std::time::Duration::from_millis(#file_watch_debounce_ms)))
+                let mut lib_loader = #crate_name::LibReloader::new(#lib_dir, #lib_name, Some(::std::time::Duration::from_millis(#file_watch_debounce_ms)), #loaded_lib_name_template)
                     .expect("failed to create hot reload loader");
 
                 let change_rx = lib_loader.subscribe_to_file_changes();

--- a/macro/src/hot_module/module_body.rs
+++ b/macro/src/hot_module/module_body.rs
@@ -235,13 +235,14 @@ impl quote::ToTokens for HotModule {
             lib_dir,
             file_watch_debounce_ms,
             crate_name,
+            loaded_lib_name_template,
         } = match hot_module_args {
             None => panic!("Expected to have macro attributes"),
             Some(attributes) => attributes,
         };
 
         let lib_loader =
-            generate_lib_loader_items(lib_dir, lib_name, file_watch_debounce_ms, crate_name, tokens.span())
+            generate_lib_loader_items(lib_dir, lib_name, file_watch_debounce_ms, crate_name, loaded_lib_name_template, tokens.span())
                 .expect("error generating hot lib loader helpers");
 
         let module_def = quote::quote! {


### PR DESCRIPTION
Draft PR fixing my issue #32 where I have multiple processes hot reloading the same file causing conflicts. Will match and use old naming scheme when not specified.
I have added a few different template values including uuid and rand (Which is an added dependency so I understand removing these).
Definitely not great at rust so there might be some mistakes here as I was just trying to get something working at the time.

Example of the macro usage
```rust
#[hot_lib_reloader::hot_module(
    loaded_lib_name_template = "{lib_name}_hot_{pid}_{load_counter}"
)]
```