### PR TITLE
upgrade to bevy  0.12.1

### DIFF
--- a/examples/bevy/Cargo.toml
+++ b/examples/bevy/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.8.0" }
+bevy = { version = "0.12.1" }
+bevy_dylib = "0.12.1"
 components = { path = "components" }
 hot-lib-reloader = { path = "../..", optional = true }
 rand = "0.8.5"
@@ -21,5 +22,5 @@ reload = [
   # Make sure that the types don't change:
   "components/dynamic",
   # This is important on windows for avoiding file locking issues:
-  "bevy/dynamic",
+  "bevy/dynamic_linking",
 ]

--- a/examples/bevy/components/Cargo.toml
+++ b/examples/bevy/components/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.8.0" }
+bevy = { version = "0.12.1" }
+bevy_dylib = "0.12.1"
 
 [features]
 default = []
-dynamic = ["bevy/dynamic"]
+dynamic = ["bevy/dynamic_linking"]

--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -16,17 +16,19 @@ mod systems_hot {
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
-        .add_startup_system(systems::setup)
-        .add_system_set(
-            SystemSet::new()
-                .with_system(player_movement_system)
-                .with_system(player_shooting_system)
-                .with_system(bullet_movement_system)
-                .with_system(bullet_hit_system)
-                .with_system(spawn_other_ships)
-                .with_system(move_other_ships),
-        )
-        .add_system(bevy::window::close_on_esc);
+        .add_systems(Startup, systems::setup)
+        .add_systems(
+            Update,
+            (
+                player_movement_system,
+                player_shooting_system,
+                bullet_movement_system,
+                bullet_hit_system,
+                spawn_other_ships,
+                move_other_ships,
+                bevy::window::close_on_esc,
+            ),
+        );
 
     app.run();
 }

--- a/examples/bevy/systems/Cargo.toml
+++ b/examples/bevy/systems/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-bevy = { version = "0.8.0" }
+bevy = { version = "0.12.1" }
+bevy_dylib = "0.12.1"
 components = { path = "../components" }
 log = "*"
 rand = "0.8.5"
 
 [features]
 default = []
-dynamic = ["bevy/dynamic", "components/dynamic"]
+dynamic = ["bevy/dynamic_linking", "components/dynamic"]

--- a/examples/bevy/systems/src/lib.rs
+++ b/examples/bevy/systems/src/lib.rs
@@ -5,12 +5,12 @@ use components::*;
 use rand::{thread_rng, Rng};
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     // player
     let ship_handle = asset_server.load("textures/simplespace/ship_C.png");
     commands
-        .spawn_bundle(SpriteBundle {
+        .spawn(SpriteBundle {
             texture: ship_handle,
             ..default()
         })
@@ -74,10 +74,10 @@ pub fn player_shooting_system(
     if keyboard_input.just_pressed(KeyCode::Space) {
         if let Ok(tfm) = query.get_single() {
             commands
-                .spawn_bundle(SpriteBundle {
+                .spawn(SpriteBundle {
                     transform: *tfm,
                     sprite: Sprite {
-                        color: Color::rgb(0.9, 0.8, 0.0),
+                        color: Color::rgb(0.9, 0.0, 0.0),
                         custom_size: Some(Vec2::new(SIZE, SIZE)),
                         ..Default::default()
                     },
@@ -186,7 +186,7 @@ pub fn spawn_other_ships(
         transform.rotate_z(dir.to_radians());
 
         commands
-            .spawn_bundle(SpriteBundle {
+            .spawn(SpriteBundle {
                 texture: asset_server.load("textures/simplespace/enemy_A.png"),
                 transform,
                 ..default()


### PR DESCRIPTION
Quick PR to update Bevy to latest (0.12.1). Tested and working on Linux, and I assume other OSes, though I have only tested the one.