### PR TITLE
parse no_mangle in cfg_attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ When you define a feature like this
 ```toml
 [features]
 default = []
-reload = ["dep:hot-lib-reloader"]
+reload = ["lib/reload", "dep:hot-lib-reloader"]
 
 [dependencies]
+lib = { path = "lib" }
 hot-lib-reloader = { version = "^0.6", optional = true }
 ```
 
@@ -283,13 +284,13 @@ use lib::*;
 mod hot_lib { /*...*/ }
 ```
 
+You can also conditionally use `#[no_mangle]` in your library:
+
+```rust
+#[cfg_attr(feature = "reload", no_mangle)]
+```
+
 To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
-
-
-### Disable `#[no-mangle]` in release mode
-
-To not pay a penalty for exposing functions using `#[no_mangle]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, you can use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
-
 
 ### Use serialization or generic values for changing types
 

--- a/examples/reload-feature/Cargo.toml
+++ b/examples/reload-feature/Cargo.toml
@@ -15,4 +15,4 @@ log = "*"
 
 [features]
 default = []
-reload = ["dep:hot-lib-reloader"]
+reload = ["lib/reload", "dep:hot-lib-reloader"]

--- a/examples/reload-feature/lib/Cargo.toml
+++ b/examples/reload-feature/lib/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [lib]
 crate-type = ["rlib", "dylib"]
+
+[features]
+default = []
+reload = []

--- a/examples/reload-feature/lib/src/lib.rs
+++ b/examples/reload-feature/lib/src/lib.rs
@@ -1,4 +1,4 @@
-#[no_mangle]
+#[cfg_attr(feature = "reload", no_mangle)]
 pub fn do_stuff() {
     println!("step called");
 }


### PR DESCRIPTION
fixes #36

the predicate currently isn't checked, which may cause false positives, but this is very unlikely to happen and this can be dealt with in the future.

i removed the documentation for #[no_mangle_if_debug] since it doesn't work with optimizations or the feature flag anyways. i think it should be deprecated.