### PR TITLE
Rust 2024 edition support 

### DIFF
--- a/examples/hot-egui/Cargo.toml
+++ b/examples/hot-egui/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2021"
 
 [dependencies]
 eframe = "0.19.0"
-hot-lib-reloader = { version = "^0.6", optional = true }
+#hot-lib-reloader = { version = "0.7.0", optional = true }
 lib = { path = "./lib" }
+
+hot-lib-reloader = { path = "C:\\dev\\hot-lib-reloader-rs", optional = true}
 
 [features]
 default = []

--- a/examples/hot-egui/Cargo.toml
+++ b/examples/hot-egui/Cargo.toml
@@ -10,10 +10,8 @@ edition = "2021"
 
 [dependencies]
 eframe = "0.19.0"
-#hot-lib-reloader = { version = "0.7.0", optional = true }
+hot-lib-reloader = { path = "./../../", optional = true }
 lib = { path = "./lib" }
-
-hot-lib-reloader = { path = "C:\\dev\\hot-lib-reloader-rs", optional = true}
 
 [features]
 default = []

--- a/examples/hot-egui/lib/Cargo.toml
+++ b/examples/hot-egui/lib/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "lib"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
 eframe = "0.19.0"
+
+[features]
+default = []
+reload = []

--- a/examples/hot-egui/lib/src/lib.rs
+++ b/examples/hot-egui/lib/src/lib.rs
@@ -14,7 +14,7 @@ impl Default for State {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn render(state: &mut State, ctx: &egui::Context, _frame: &mut eframe::Frame) {
     egui::CentralPanel::default().show(ctx, |ui| {
         // ctx.set_pixels_per_point(2.0);

--- a/examples/hot-egui/runcc.yml
+++ b/examples/hot-egui/runcc.yml
@@ -2,4 +2,4 @@ commands:
   bin: |
     cargo run --features reload
   lib: |
-    cargo watch -w lib -x "build -p lib"
+    cargo watch -w lib -x "build -p lib --features reload"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 proc-macro2 = "1.0.42"
 quote = "1.0"
 # syn = { version = "1.0", features = ["full", "extra-traits"] }
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0.98", features = ["full"] }

--- a/macro/src/hot_module/code_gen.rs
+++ b/macro/src/hot_module/code_gen.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Span;
-use syn::{token, Expr, Path, FnArg, ItemFn, LitByteStr, LitStr, Result, VisPublic, Visibility};
+use syn::{token, Expr, Path, FnArg, ItemFn, LitByteStr, LitStr, Result, Visibility};
 use syn::{ForeignItemFn, LitInt};
 
 use crate::util::ident_from_pat;
@@ -172,9 +172,7 @@ pub(crate) fn gen_hot_module_function_for(
     // function using message sending
     let function = ItemFn {
         attrs: Vec::new(),
-        vis: Visibility::Public(VisPublic {
-            pub_token: token::Pub(Span::call_site()),
-        }),
+        vis: Visibility::Public(token::Pub(Span::call_site())),
         sig,
         block,
     };

--- a/macro/src/hot_module/module_body.rs
+++ b/macro/src/hot_module/module_body.rs
@@ -105,7 +105,7 @@ impl syn::parse::Parse for HotModule {
                     if func
                         .attrs
                         .iter()
-                        .any(|attr| attr.path.is_ident("lib_change_subscription")) =>
+                        .any(|attr| attr.path().is_ident("lib_change_subscription")) =>
                 {
                     let span = func.span();
                     let f = ForeignItemFn {
@@ -125,7 +125,7 @@ impl syn::parse::Parse for HotModule {
                     if func
                         .attrs
                         .iter()
-                        .any(|attr| attr.path.is_ident("lib_version")) =>
+                        .any(|attr| attr.path().is_ident("lib_version")) =>
                 {
                     let span = func.span();
                     let f = ForeignItemFn {
@@ -145,7 +145,7 @@ impl syn::parse::Parse for HotModule {
                     if func
                         .attrs
                         .iter()
-                        .any(|attr| attr.path.is_ident("lib_updated")) =>
+                        .any(|attr| attr.path().is_ident("lib_updated")) =>
                 {
                     let span = func.span();
                     let f = ForeignItemFn {
@@ -165,7 +165,7 @@ impl syn::parse::Parse for HotModule {
                     if func
                         .attrs
                         .iter()
-                        .any(|attr| attr.path.is_ident("hot_function")) =>
+                        .any(|attr| attr.path().is_ident("hot_function")) =>
                 {
                     let span = func.span();
                     let f = ForeignItemFn {
@@ -187,7 +187,7 @@ impl syn::parse::Parse for HotModule {
                     if foreign_mod
                         .attrs
                         .iter()
-                        .any(|attr| attr.path.is_ident("hot_functions")) =>
+                        .any(|attr| attr.path().is_ident("hot_functions")) =>
                 {
                     for item in foreign_mod.items {
                         match item {

--- a/macro/src/lib_reloader/bevy_system_functions.rs
+++ b/macro/src/lib_reloader/bevy_system_functions.rs
@@ -44,9 +44,7 @@ pub(crate) fn generate_bevy_system_functions(
 
         let bevy_system_func = syn::ItemFn {
             attrs: Vec::new(),
-            vis: syn::Visibility::Public(syn::VisPublic {
-                pub_token: syn::token::Pub(*span),
-            }),
+            vis: syn::Visibility::Public(syn::token::Pub(*span)),
             sig,
             block,
         };

--- a/macro/src/lib_reloader/generate_libreloader_struct.rs
+++ b/macro/src/lib_reloader/generate_libreloader_struct.rs
@@ -1,8 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use syn::{
-    parse_quote, token, FnArg, ForeignItemFn, Ident, ImplItemMethod, LitByteStr, LitStr, Receiver,
-    Result, VisPublic, Visibility,
-};
+use syn::{parse_quote, token, FnArg, ForeignItemFn, Ident, ImplItem, ImplItemFn, LitByteStr, LitStr, Receiver, Result, Type, Visibility};
 
 use crate::util::ident_from_pat;
 
@@ -49,10 +46,10 @@ pub fn generate_lib_reloader_struct(
 /// 2. It generates a function signature that can be used as signature of a
 /// method for the specific LibReloader struct.
 ///
-/// Those two things are then put together to create a [syn::ImplItemMethod].
+/// Those two things are then put together to create a [syn::ImplItemFn].
 fn generate_impl_method_to_call_lib_function(
     (lib_function, span): (ForeignItemFn, Span),
-) -> Result<ImplItemMethod> {
+) -> Result<ImplItemFn> {
     let ForeignItemFn { attrs, sig, .. } = lib_function;
 
     // the symbol inside the library we call needs to be a byte string
@@ -104,15 +101,15 @@ fn generate_impl_method_to_call_lib_function(
             attrs: Vec::new(),
             mutability: None,
             self_token: token::SelfValue(Span::call_site()),
+            colon_token: None,
             reference: Some((token::And(Span::call_site()), None)),
+            ty: Box::new(Type::Verbatim(TokenStream::new())),
         }),
     );
 
-    Ok(ImplItemMethod {
+    Ok(ImplItemFn  {
         attrs,
-        vis: Visibility::Public(VisPublic {
-            pub_token: token::Pub(Span::call_site()),
-        }),
+        vis: Visibility::Public(token::Pub(Span::call_site())),
         defaultness: None,
         sig,
         block,

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -50,13 +50,71 @@ pub fn read_functions_from_file(
                 // we can optionally assume that the function will be unmangled
                 // by other means than a direct attribute
                 if !ignore_no_mangle {
-                    let no_mangle = fun
-                        .attrs
-                        .iter()
-                        .filter_map(|attr| attr.path.get_ident())
-                        .any(|ident| *ident == "no_mangle");
+                    fn cfg_no_mangle<'a>(
+                        mut cfg_items: impl Iterator<Item = &'a syn::Meta>,
+                    ) -> bool {
+                        let _predicate = cfg_items.next();
+                        // TODO: return false if predicate is false
+                        // false positives are unlikely, but can still compile error
+                        cfg_items.any(|meta| match meta {
+                            syn::Meta::Path(path) => {
+                                path.is_ident("no_mangle")
+                            },
+                            syn::Meta::List(list) => {
+                                let mut found_no_mangle = false;
+                                if let Err(_) = list.parse_nested_meta(|meta| {
+                                    println!("meta.path: {:?}", meta.path);
+                                    if meta.path.is_ident("no_mangle") {
+                                        println!("no_mangle");
+                                        found_no_mangle = true;
+                                    }
+                                    Ok(())
+                                }) {
+                                    return false;
+                                }
+                                found_no_mangle
+                            }
 
-                    if !no_mangle {
+                            _ => false,
+                        })
+                    }
+
+                    fn is_no_mangle<'a>(
+                        mut attrs: impl Iterator<Item = &'a syn::Attribute>,
+                    ) -> bool {
+                        attrs.any(|attr| {
+                            let ident = match attr.path().get_ident() {
+                                Some(i) => i,
+                                None => return false,
+                            };
+                            if *ident == "no_mangle" {
+                                true
+                            } else if *ident == "unsafe" {
+                                println!("found unsafe");
+                                let mut found_no_mangle = false;
+                                if let Err(_) = attr.parse_nested_meta(|meta| {
+                                    if meta.path.is_ident("no_mangle") {
+                                        found_no_mangle = true;
+                                    }
+                                    Ok(())
+                                }) {
+                                    return false;
+                                }
+                                found_no_mangle
+                            } else if *ident == "cfg_attr" {
+                                println!("found cfg_attr");
+                                let nested = match attr.parse_args_with(syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated) {
+                                    Ok(nested) => nested,
+                                    _ => return false,
+                                };
+                                cfg_no_mangle(nested.iter())
+                            } else {
+                                false
+                            }
+                        })
+                    }
+
+                    if !is_no_mangle(fun.attrs.iter()) {
                         continue;
                     };
                 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -57,15 +57,11 @@ pub fn read_functions_from_file(
                         // TODO: return false if predicate is false
                         // false positives are unlikely, but can still compile error
                         cfg_items.any(|meta| match meta {
-                            syn::Meta::Path(path) => {
-                                path.is_ident("no_mangle")
-                            },
+                            syn::Meta::Path(path) => path.is_ident("no_mangle"),
                             syn::Meta::List(list) => {
                                 let mut found_no_mangle = false;
                                 if let Err(_) = list.parse_nested_meta(|meta| {
-                                    println!("meta.path: {:?}", meta.path);
                                     if meta.path.is_ident("no_mangle") {
-                                        println!("no_mangle");
                                         found_no_mangle = true;
                                     }
                                     Ok(())
@@ -90,7 +86,6 @@ pub fn read_functions_from_file(
                             if *ident == "no_mangle" {
                                 true
                             } else if *ident == "unsafe" {
-                                println!("found unsafe");
                                 let mut found_no_mangle = false;
                                 if let Err(_) = attr.parse_nested_meta(|meta| {
                                     if meta.path.is_ident("no_mangle") {
@@ -102,7 +97,6 @@ pub fn read_functions_from_file(
                                 }
                                 found_no_mangle
                             } else if *ident == "cfg_attr" {
-                                println!("found cfg_attr");
                                 let nested = match attr.parse_args_with(syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated) {
                                     Ok(nested) => nested,
                                     _ => return false,


### PR DESCRIPTION
https://github.com/nmeylan/hot-lib-reloader-rs had implemented support for rust 2024 edition.

Cleaned it a little bit up, seems to work.