### PR TITLE
`no_mangle` with `cfg_attr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,10 @@ When you define a feature like this
 ```toml
 [features]
 default = []
-reload = ["dep:hot-lib-reloader"]
+reload = ["lib/reload", "dep:hot-lib-reloader"]
 
 [dependencies]
+lib = { path = "lib" }
 hot-lib-reloader = { version = "^0.6", optional = true }
 ```
 
@@ -294,13 +295,23 @@ use lib::*;
 mod hot_lib { /*...*/ }
 ```
 
-To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
-
-
 ### Disable `#[no-mangle]` in release mode
 
-To not pay a penalty for exposing functions using `#[unsafe(no_mangle)]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, you can use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
+To not pay a penalty for exposing functions using `#[unsafe(no_mangle)]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, there are two options:
 
+#### With a feature flag
+
+Conditionally use `#[no_mangle]` in your library:
+
+```rust
+#[cfg_attr(feature = "reload", no_mangle)]
+```
+
+To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
+
+#### Using `no-mangle-if-debug` macro
+
+Use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
 
 ### Use serialization or generic values for changing types
 

--- a/README.md
+++ b/README.md
@@ -295,23 +295,27 @@ use lib::*;
 mod hot_lib { /*...*/ }
 ```
 
-### Disable `#[no-mangle]` in release mode
+To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
+
+
+#### Disable `#[no-mangle]` in release mode
 
 To not pay a penalty for exposing functions using `#[unsafe(no_mangle)]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, there are two options:
 
-#### With a feature flag
+##### With a feature flag
 
 Conditionally use `#[no_mangle]` in your library:
 
 ```rust
-#[cfg_attr(feature = "reload", no_mangle)]
+#[cfg_attr(feature = "reload", unsafe(no_mangle))]
 ```
 
 To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
 
-#### Using `no-mangle-if-debug` macro
+##### Using `no-mangle-if-debug` macro
 
 Use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
+
 
 ### Use serialization or generic values for changing types
 

--- a/examples/reload-feature/Cargo.toml
+++ b/examples/reload-feature/Cargo.toml
@@ -15,4 +15,4 @@ log = "*"
 
 [features]
 default = []
-reload = ["dep:hot-lib-reloader"]
+reload = ["lib/reload", "dep:hot-lib-reloader"]

--- a/examples/reload-feature/lib/Cargo.toml
+++ b/examples/reload-feature/lib/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [lib]
 crate-type = ["rlib", "dylib"]
+
+[features]
+default = []
+reload = []

--- a/examples/reload-feature/lib/src/lib.rs
+++ b/examples/reload-feature/lib/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg_attr(feature = "reload", no_mangle)]
+#[cfg_attr(feature = "reload", unsafe(no_mangle))]
 pub fn do_stuff() {
     println!("step called");
 }

--- a/examples/reload-feature/lib/src/lib.rs
+++ b/examples/reload-feature/lib/src/lib.rs
@@ -1,4 +1,4 @@
-#[unsafe(no_mangle)]
+#[cfg_attr(feature = "reload", no_mangle)]
 pub fn do_stuff() {
     println!("step called");
 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -58,28 +58,49 @@ pub fn read_functions_from_file(
                 // we can optionally assume that the function will be unmangled
                 // by other means than a direct attribute
                 if !ignore_no_mangle {
-                    let no_mangle = fun
-                        .attrs
-                        .iter()
-                        .filter_map(|attr| attr.path().get_ident())
-                        .any(|ident| *ident == "no_mangle");
+                    fn cfg_no_mangle<'a>(
+                        mut cfg_items: impl Iterator<Item = &'a syn::NestedMeta>,
+                    ) -> bool {
+                        let _predicate = cfg_items.next();
+                        // TODO: return false if predicate is false
+                        // false positives are unlikely, but can still compile error
 
-                    let unsafe_no_mangle = fun.attrs.iter().any(|attr| {
-                        attr.meta.require_list().is_ok_and(|list| {
-                            list.path
-                                .get_ident()
-                                .is_some_and(|ident| *ident == "unsafe")
-                                && list.tokens.clone().into_iter().any(|token| {
-                                    if let TokenTree::Ident(ident) = token {
-                                        ident == "no_mangle"
-                                    } else {
-                                        false
-                                    }
-                                })
+                        cfg_items.any(|meta| {
+                            let meta = match meta {
+                                syn::NestedMeta::Meta(m) => m,
+                                _ => return false,
+                            };
+                            match meta {
+                                syn::Meta::Path(path) => path.is_ident("no_mangle"),
+                                syn::Meta::List(m) => cfg_no_mangle(m.nested.iter()),
+                                _ => false,
+                            }
                         })
-                    });
+                    }
 
-                    if !no_mangle && !unsafe_no_mangle {
+                    fn is_no_mangle<'a>(
+                        mut attrs: impl Iterator<Item = &'a syn::Attribute>,
+                    ) -> bool {
+                        attrs.any(|attr| {
+                            let ident = match attr.path.get_ident() {
+                                Some(i) => i,
+                                None => return false,
+                            };
+                            if *ident == "no_mangle" {
+                                true
+                            } else if *ident == "cfg_attr" {
+                                let nested = match attr.parse_meta() {
+                                    Ok(syn::Meta::List(m)) => m.nested,
+                                    _ => return false,
+                                };
+                                cfg_no_mangle(nested.iter())
+                            } else {
+                                false
+                            }
+                        })
+                    }
+
+                    if !is_no_mangle(fun.attrs.iter()) {
                         continue;
                     };
                 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -1,6 +1,5 @@
+use proc_macro2::Span;
 use std::path::PathBuf;
-
-use proc_macro2::{Span, TokenTree};
 use syn::{Error, ForeignItemFn, LitStr, Result};
 
 pub fn ident_from_pat(
@@ -22,8 +21,9 @@ pub fn ident_from_pat(
 /// Reads the contents of a Rust source file and finds the top-level functions that have
 /// - visibility public
 /// - #[unsafe(no_mangle)] attribute
-///   It converts these functions into a [syn::ForeignItemFn] so that those can
-///   serve as lib function declarations of the lib reloader.
+///
+/// It converts these functions into a [syn::ForeignItemFn] so that those can
+/// serve as lib function declarations of the lib reloader.
 pub fn read_functions_from_file(
     file_name: LitStr,
     ignore_no_mangle: bool,
@@ -59,22 +59,30 @@ pub fn read_functions_from_file(
                 // by other means than a direct attribute
                 if !ignore_no_mangle {
                     fn cfg_no_mangle<'a>(
-                        mut cfg_items: impl Iterator<Item = &'a syn::NestedMeta>,
+                        mut cfg_items: impl Iterator<Item = &'a syn::Meta>,
                     ) -> bool {
                         let _predicate = cfg_items.next();
                         // TODO: return false if predicate is false
                         // false positives are unlikely, but can still compile error
-
-                        cfg_items.any(|meta| {
-                            let meta = match meta {
-                                syn::NestedMeta::Meta(m) => m,
-                                _ => return false,
-                            };
-                            match meta {
-                                syn::Meta::Path(path) => path.is_ident("no_mangle"),
-                                syn::Meta::List(m) => cfg_no_mangle(m.nested.iter()),
-                                _ => false,
+                        cfg_items.any(|meta| match meta {
+                            syn::Meta::Path(path) => path.is_ident("no_mangle"),
+                            syn::Meta::List(list) => {
+                                let mut found_no_mangle = false;
+                                if list
+                                    .parse_nested_meta(|meta| {
+                                        if meta.path.is_ident("no_mangle") {
+                                            found_no_mangle = true;
+                                        }
+                                        Ok(())
+                                    })
+                                    .is_err()
+                                {
+                                    return false;
+                                }
+                                found_no_mangle
                             }
+
+                            _ => false,
                         })
                     }
 
@@ -82,15 +90,26 @@ pub fn read_functions_from_file(
                         mut attrs: impl Iterator<Item = &'a syn::Attribute>,
                     ) -> bool {
                         attrs.any(|attr| {
-                            let ident = match attr.path.get_ident() {
+                            let ident = match attr.path().get_ident() {
                                 Some(i) => i,
                                 None => return false,
                             };
                             if *ident == "no_mangle" {
                                 true
+                            } else if *ident == "unsafe" {
+                                let mut found_no_mangle = false;
+                                if attr.parse_nested_meta(|meta| {
+                                    if meta.path.is_ident("no_mangle") {
+                                        found_no_mangle = true;
+                                    }
+                                    Ok(())
+                                }).is_err() {
+                                    return false;
+                                }
+                                found_no_mangle
                             } else if *ident == "cfg_attr" {
-                                let nested = match attr.parse_meta() {
-                                    Ok(syn::Meta::List(m)) => m.nested,
+                                let nested = match attr.parse_args_with(syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated) {
+                                    Ok(nested) => nested,
                                     _ => return false,
                                 };
                                 cfg_no_mangle(nested.iter())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,9 +269,10 @@ When you define a feature like this
 ```toml
 [features]
 default = []
-reload = ["dep:hot-lib-reloader"]
+reload = ["lib/reload", "dep:hot-lib-reloader"]
 
 [dependencies]
+lib = { path = "lib" }
 hot-lib-reloader = { version = "^0.6", optional = true }
 ```
 
@@ -291,9 +292,23 @@ mod hot_lib { /*...*/ }
 To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
 
 
-## Disable `#[no-mangle]` in release mode
+### Disable `#[no-mangle]` in release mode
 
-To not pay a penalty for exposing functions using `#[unsafe(no_mangle)]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, you can use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
+To not pay a penalty for exposing functions using `#[unsafe(no_mangle)]` in release mode where everything is statically compiled (see previous tip) and no functions need to be exported, there are two options:
+
+#### With a feature flag
+
+Conditionally use `#[no_mangle]` in your library:
+
+```rust
+#[cfg_attr(feature = "reload", unsafe(no_mangle))]
+```
+
+To run the static version just use `cargo run` the hot reloadable variant with `cargo run --features reload`.
+
+#### Using `no-mangle-if-debug` macro
+
+Use the [no-mangle-if-debug attribute macro](./macro-no-mangle-if-debug). It will conditionally disable name mangling, depending on wether you build release or debug mode.
 
 
 ## Use serialization or generic values for changing types


### PR DESCRIPTION
This adds support for compile-time conditional `no_mangle` via a `#[cfg_attr(feature = "reload", unsafe(no_mangle))]` annotation.

Based on:
- #45
- #41 (fixes #41)

Thank you @SArpnt!